### PR TITLE
chore: export namespaces to allow typings reuse

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,5 @@
 
-declare namespace Events {
+export namespace Events {
 
 	interface BaseEvent {}
 
@@ -112,7 +112,7 @@ declare namespace Events {
 }
 
 
-declare namespace Sdl {
+export namespace Sdl {
 
 	interface Info {
 		readonly version: {
@@ -731,5 +731,5 @@ declare namespace Sdl {
 	}
 }
 
-declare const sdl: Sdl.Module
-export default sdl
+const sdl: Sdl.Module
+export = sdl


### PR DESCRIPTION
I wanted to use `Window` type in my TS project from `Sdl.Video.Window` but `Sdl` namespace is not available. So I exported it as well as `Events` namespace.

Also:
```ts
const sdl: Sdl.Module
export = sdl
```
this is more correct for `module.exports = sdl`