### PR TITLE
ES Modules Porting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "0.6.8",
   "name": "@kmamal/sdl",
   "description": "SDL bindings for Node.js",
+  "type": "module",
   "keywords": [
     "sdl",
     "sdl2",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
-import Fs from 'node:fs'
-import Path from 'node:path'
-import { execSync } from 'node:child_process'
+import * as Fs from 'fs'
+import * as Path from 'path'
+import { execSync } from 'child_process'
 import C from './util/common.js'
 
 await Promise.all([

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,5 +1,5 @@
-import Fs from 'node:fs'
-import Path from 'node:path'
+import * as Fs from 'fs'
+import * as Path from 'path'
 import C from './util/common.js'
 
 const dirs = [

--- a/scripts/download-release.mjs
+++ b/scripts/download-release.mjs
@@ -1,5 +1,5 @@
-import Fs from 'node:fs'
-import { once } from 'node:events'
+import * as Fs from 'fs'
+import { once } from "events"
 import C from './util/common.js'
 import { fetch } from './util/fetch.js'
 import Tar from 'tar'

--- a/scripts/download-sdl.mjs
+++ b/scripts/download-sdl.mjs
@@ -1,5 +1,5 @@
-import Fs from 'node:fs'
-import { once } from 'node:events'
+import * as Fs from 'fs'
+import { once } from "events"
 import C from './util/common.js'
 import { fetch } from './util/fetch.js'
 import Tar from 'tar'
@@ -10,7 +10,7 @@ console.log("fetch", url)
 const response = await fetch(url)
 
 console.log("unpack to", C.dir.sdl)
-await Fs.promises.rm(C.dir.sdl, { recursive: true }).catch(() => {})
+await Fs.promises.rm(C.dir.sdl, { recursive: true }).catch(() => { })
 await Fs.promises.mkdir(C.dir.sdl, { recursive: true })
 const tar = Tar.extract({ gzip: true, C: C.dir.sdl })
 response.stream().pipe(tar)

--- a/scripts/install-deps-mac.sh
+++ b/scripts/install-deps-mac.sh
@@ -1,2 +1,1 @@
-
 brew install xquartz

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1,4 +1,3 @@
-
 if (!process.env.NODE_SDL_FROM_SOURCE) {
 	try {
 		await import('./download-release.mjs')

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execSync } from 'child_process'
 
 await import('./clean.mjs')
 

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,6 +1,6 @@
-import Path from 'node:path'
-import { execSync } from 'node:child_process'
-import { fstat } from 'node:fs'
+import * as Path from 'path'
+import { execSync } from 'child_process'
+import { fstat } from 'fs'
 
 process.chdir(Path.resolve(__dirname, '../tests'))
 const files = await fstat.readdir('.')

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,8 +1,10 @@
 import * as Path from 'path'
 import { execSync } from 'child_process'
 import { fstat } from 'fs'
+import { fileURLToPath } from 'url'
+const __dirname = Path.dirname(fileURLToPath(import.meta.url))
 
-process.chdir(Path.resolve(__dirname, '../tests'))
+process.chdir(Path.join(__dirname, '../tests'))
 const files = await fstat.readdir('.')
 for (const name of files) {
 	if (!name.endsWith('.test.js')) { continue }

--- a/scripts/upload-release.mjs
+++ b/scripts/upload-release.mjs
@@ -1,5 +1,5 @@
-import Fs from 'node:fs'
-import Path from 'node:path'
+import * as Fs from 'fs'
+import * as Path from 'path'
 import C from './util/common.js'
 import { fetch } from './util/fetch.js'
 import Tar from 'tar'

--- a/scripts/util/common.js
+++ b/scripts/util/common.js
@@ -1,8 +1,9 @@
-const Fs = require('node:fs')
-const Path = require('node:path')
-
+import * as Fs from 'fs'
+import * as Path from 'path'
+import { fileURLToPath } from 'url'
 const dir = {}
-dir.root = Path.resolve(__dirname, '../..')
+const __dirname = Path.dirname(fileURLToPath(import.meta.url))
+dir.root = Path.join(__dirname, '../..')
 dir.sdl = Path.join(dir.root, 'sdl')
 dir.build = Path.join(dir.root, 'build')
 dir.dist = Path.join(dir.root, 'dist')
@@ -11,7 +12,7 @@ dir.publish = Path.join(dir.root, 'publish')
 const pkgPath = Path.join(dir.root, 'package.json')
 const pkg = JSON.parse(Fs.readFileSync(pkgPath).toString())
 const version = pkg.version
-const [ , owner, repo ] = pkg.repository.url.match(/([^/:]+)\/([^/]+).git$/u)
+const [, owner, repo] = pkg.repository.url.match(/([^/:]+)\/([^/]+).git$/u)
 
 const { platform, arch } = process
 const targetArch = process.env.CROSS_COMPILE_ARCH || arch
@@ -20,7 +21,7 @@ const assetName = `sdl.node-v${version}-${platform}-${targetArch}.tar.gz`
 const sdl = pkg.sdl
 sdl.assetName = `SDL-v${sdl.version}-${platform}-${targetArch}.tar.gz`
 
-module.exports = {
+export default {
 	dir,
 	version,
 	owner,

--- a/scripts/util/fetch.js
+++ b/scripts/util/fetch.js
@@ -1,4 +1,3 @@
-
 const _consume = async (stream) => {
 	const chunks = []
 	for await (const chunk of stream) {
@@ -7,7 +6,7 @@ const _consume = async (stream) => {
 	return Buffer.concat(chunks)
 }
 
-const fetch = async (_url, options = {}) => {
+export const fetch = async (_url, options = {}) => {
 	let url = _url
 	let {
 		maxRedirect = 5,
@@ -15,7 +14,7 @@ const fetch = async (_url, options = {}) => {
 	} = options
 
 	const { protocol } = new URL(url)
-	const lib = require(protocol.slice(0, -1))
+	const lib = await import(protocol.slice(0, -1))
 
 	const evalPromise = (resolve, reject) => {
 		const request = lib.request(url, options)
@@ -78,5 +77,3 @@ const fetch = async (_url, options = {}) => {
 		}
 	}
 }
-
-module.exports = { fetch }

--- a/src/javascript/audio/audio-instance.js
+++ b/src/javascript/audio/audio-instance.js
@@ -1,8 +1,10 @@
-const Bindings = require('../bindings')
-const Enums = require('../enums')
+// TODO: handle import issues here
+
+const Bindings = require('../bindings').default
+const Enums = require('../enums').default
 const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
-const { AudioFormatHelpers } = require('./format-helpers')
+const { EventsViaPoll } = require('../events/events-via-poll').default
+const { AudioFormatHelpers } = require('./format-helpers').default
 
 const validEvents = [ 'close' ]
 

--- a/src/javascript/audio/audio-instance.js
+++ b/src/javascript/audio/audio-instance.js
@@ -1,12 +1,12 @@
-import * as Bindings from '../bindings'
-import * as Enums from '../enums'
-import * as Globals from '../globals'
-import { EventsViaPoll } from '../events/events-via-poll'
-import { AudioFormatHelpers } from './format-helpers'
+import * as Bindings from '../bindings.js'
+import * as Enums from '../enums.js'
+import * as Globals from '../globals.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
+import { AudioFormatHelpers } from './format-helpers.js'
 
 const validEvents = [ 'close' ]
 
-class AudioInstance extends EventsViaPoll {
+export class AudioInstance extends EventsViaPoll {
 	constructor (device, options) {
 		super(validEvents)
 
@@ -123,5 +123,3 @@ class AudioInstance extends EventsViaPoll {
 		Globals.audioInstances.delete(this._id)
 	}
 }
-
-module.exports = { AudioInstance }

--- a/src/javascript/audio/audio-instance.js
+++ b/src/javascript/audio/audio-instance.js
@@ -1,10 +1,8 @@
-// TODO: handle import issues here
-
-const Bindings = require('../bindings').default
-const Enums = require('../enums').default
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll').default
-const { AudioFormatHelpers } = require('./format-helpers').default
+import * as Bindings from '../bindings'
+import * as Enums from '../enums'
+import * as Globals from '../globals'
+import { EventsViaPoll } from '../events/events-via-poll'
+import { AudioFormatHelpers } from './format-helpers'
 
 const validEvents = [ 'close' ]
 

--- a/src/javascript/audio/audio-playback-instance.js
+++ b/src/javascript/audio/audio-playback-instance.js
@@ -1,5 +1,7 @@
-const Bindings = require('../bindings')
-const { AudioInstance } = require('./audio-instance')
+// TODO: handle import issues here
+
+import Bindings from '../bindings'
+import { AudioInstance } from './audio-instance'
 
 class AudioPlaybackInstance extends AudioInstance {
 	enqueue (buffer, numBytes = buffer.length) {
@@ -13,4 +15,4 @@ class AudioPlaybackInstance extends AudioInstance {
 	}
 }
 
-module.exports = { AudioPlaybackInstance }
+export default { AudioPlaybackInstance }

--- a/src/javascript/audio/audio-playback-instance.js
+++ b/src/javascript/audio/audio-playback-instance.js
@@ -1,10 +1,8 @@
-// TODO: handle import issues here
-
 import Bindings from '../bindings'
 import { AudioInstance } from './audio-instance'
 
-class AudioPlaybackInstance extends AudioInstance {
-	enqueue (buffer, numBytes = buffer.length) {
+export default class AudioPlaybackInstance extends AudioInstance {
+	enqueue(buffer, numBytes = buffer.length) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._id }) }
 
 		if (!(buffer instanceof Buffer)) { throw Object.assign(new Error("buffer must be a Buffer"), { buffer }) }
@@ -14,5 +12,3 @@ class AudioPlaybackInstance extends AudioInstance {
 		Bindings.audio_enqueue(this._id, buffer, numBytes)
 	}
 }
-
-export default { AudioPlaybackInstance }

--- a/src/javascript/audio/audio-playback-instance.js
+++ b/src/javascript/audio/audio-playback-instance.js
@@ -1,7 +1,7 @@
-import Bindings from '../bindings'
-import { AudioInstance } from './audio-instance'
+import Bindings from '../bindings.js'
+import { AudioInstance } from './audio-instance.js'
 
-export default class AudioPlaybackInstance extends AudioInstance {
+export class AudioPlaybackInstance extends AudioInstance {
 	enqueue(buffer, numBytes = buffer.length) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._id }) }
 

--- a/src/javascript/audio/audio-recording-instance.js
+++ b/src/javascript/audio/audio-recording-instance.js
@@ -1,4 +1,4 @@
-const Bindings = require('../bindings')
+const Bindings = require('../bindings').default
 const { AudioInstance } = require('./audio-instance')
 
 class AudioRecordingInstance extends AudioInstance {

--- a/src/javascript/audio/audio-recording-instance.js
+++ b/src/javascript/audio/audio-recording-instance.js
@@ -1,7 +1,6 @@
-const Bindings = require('../bindings').default
-const { AudioInstance } = require('./audio-instance')
-
-class AudioRecordingInstance extends AudioInstance {
+import Bindings from '../bindings.js'
+import { AudioInstance } from './audio-instance.js'
+export class AudioRecordingInstance extends AudioInstance {
 	dequeue (buffer, numBytes = buffer.length) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._id }) }
 
@@ -12,5 +11,3 @@ class AudioRecordingInstance extends AudioInstance {
 		return Bindings.audio_dequeue(this._id, buffer, numBytes)
 	}
 }
-
-module.exports = { AudioRecordingInstance }

--- a/src/javascript/audio/device.js
+++ b/src/javascript/audio/device.js
@@ -1,17 +1,12 @@
-const make = (device) => {
+export const make = (device) => {
 	const { isRecorder } = device
 	delete device.isRecorder
 	device.type = isRecorder ? 'recording' : 'playback'
 }
 
-const compare = (a, b) => {
+export const compare = (a, b) => {
 	const { name: aName } = a
 	const { name: bName } = b
 	if (aName === bName) { return 0 }
 	return a.name < b.name ? -1 : 1
-}
-
-export default {
-	make,
-	compare,
 }

--- a/src/javascript/audio/device.js
+++ b/src/javascript/audio/device.js
@@ -1,4 +1,3 @@
-
 const make = (device) => {
 	const { isRecorder } = device
 	delete device.isRecorder

--- a/src/javascript/audio/device.js
+++ b/src/javascript/audio/device.js
@@ -12,7 +12,7 @@ const compare = (a, b) => {
 	return a.name < b.name ? -1 : 1
 }
 
-module.exports = {
+export default {
 	make,
 	compare,
 }

--- a/src/javascript/audio/format-helpers.js
+++ b/src/javascript/audio/format-helpers.js
@@ -21,7 +21,7 @@ const floatLimits = {
 	maxSampleValue: 1,
 }
 
-const AudioFormatHelpers = {
+export default AudioFormatHelpers = {
 	s8: {
 		readerName: 'readInt8',
 		writerName: 'writeInt8',
@@ -95,5 +95,3 @@ for (const helper of Object.values(AudioFormatHelpers)) {
 	helper.reader = Buffer.prototype[helper.readerName]
 	helper.writer = Buffer.prototype[helper.writerName]
 }
-
-export default { AudioFormatHelpers }

--- a/src/javascript/audio/format-helpers.js
+++ b/src/javascript/audio/format-helpers.js
@@ -1,4 +1,4 @@
-const Os = require('os')
+import { endianness } from 'os'
 
 const signedLimits = (bits) => ({
 	bytesPerSample: bits / 8,
@@ -79,7 +79,7 @@ AudioFormatHelpers.u16 = AudioFormatHelpers.u16lsb
 AudioFormatHelpers.s32 = AudioFormatHelpers.s32lsb
 AudioFormatHelpers.f32 = AudioFormatHelpers.f32lsb
 
-if (Os.endianness() === 'LE') {
+if (endianness() === 'LE') {
 	AudioFormatHelpers.s16sys = AudioFormatHelpers.s16lsb
 	AudioFormatHelpers.u16sys = AudioFormatHelpers.u16lsb
 	AudioFormatHelpers.s32sys = AudioFormatHelpers.s32lsb
@@ -96,4 +96,4 @@ for (const helper of Object.values(AudioFormatHelpers)) {
 	helper.writer = Buffer.prototype[helper.writerName]
 }
 
-module.exports = { AudioFormatHelpers }
+export default { AudioFormatHelpers }

--- a/src/javascript/audio/format-helpers.js
+++ b/src/javascript/audio/format-helpers.js
@@ -21,7 +21,7 @@ const floatLimits = {
 	maxSampleValue: 1,
 }
 
-export default AudioFormatHelpers = {
+export const AudioFormatHelpers = {
 	s8: {
 		readerName: 'readInt8',
 		writerName: 'writeInt8',

--- a/src/javascript/audio/index.js
+++ b/src/javascript/audio/index.js
@@ -1,8 +1,10 @@
+// TODO: handle import issues here
+
 const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
-const { AudioPlaybackInstance } = require('./audio-playback-instance')
+const { EventsViaPoll } = require('../events/events-via-poll').default
+const { AudioPlaybackInstance } = require('./audio-playback-instance').default
 const { AudioRecordingInstance } = require('./audio-recording-instance')
-const { AudioFormatHelpers } = require('./format-helpers')
+const { AudioFormatHelpers } = require('./format-helpers').default
 
 const validEvents = [ 'deviceAdd', 'deviceRemove' ]
 

--- a/src/javascript/audio/index.js
+++ b/src/javascript/audio/index.js
@@ -1,14 +1,12 @@
-// TODO: handle import issues here
-
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll').default
-const { AudioPlaybackInstance } = require('./audio-playback-instance').default
-const { AudioRecordingInstance } = require('./audio-recording-instance')
-const { AudioFormatHelpers } = require('./format-helpers').default
+import Globals from '../globals'
+import { EventsViaPoll } from '../events/events-via-poll'
+import { AudioPlaybackInstance } from './audio-playback-instance'
+import { AudioRecordingInstance } from './audio-recording-instance'
+import { AudioFormatHelpers } from'./format-helpers'
 
 const validEvents = [ 'deviceAdd', 'deviceRemove' ]
 
-const audio = new class extends EventsViaPoll {
+export class audio extends EventsViaPoll {
 	constructor () { super(validEvents) }
 
 	get devices () {
@@ -44,6 +42,4 @@ const audio = new class extends EventsViaPoll {
 	writerName (format) {
 		return AudioFormatHelpers[format].writerName
 	}
-}()
-
-module.exports = { audio }
+}

--- a/src/javascript/audio/index.js
+++ b/src/javascript/audio/index.js
@@ -6,7 +6,7 @@ import { AudioFormatHelpers } from './format-helpers.js'
 
 const validEvents = ['deviceAdd', 'deviceRemove']
 
-export class audio extends EventsViaPoll {
+class AudioEventsPoll extends EventsViaPoll {
 	constructor() { super(validEvents) }
 
 	get devices() {
@@ -43,3 +43,5 @@ export class audio extends EventsViaPoll {
 		return AudioFormatHelpers[format].writerName
 	}
 }
+
+export const audio = new AudioEventsPoll();

--- a/src/javascript/audio/index.js
+++ b/src/javascript/audio/index.js
@@ -1,45 +1,45 @@
-import Globals from '../globals'
-import { EventsViaPoll } from '../events/events-via-poll'
-import { AudioPlaybackInstance } from './audio-playback-instance'
-import { AudioRecordingInstance } from './audio-recording-instance'
-import { AudioFormatHelpers } from'./format-helpers'
+import * as Globals from '../globals.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
+import { AudioPlaybackInstance } from './audio-playback-instance.js'
+import { AudioRecordingInstance } from './audio-recording-instance.js'
+import { AudioFormatHelpers } from './format-helpers.js'
 
-const validEvents = [ 'deviceAdd', 'deviceRemove' ]
+const validEvents = ['deviceAdd', 'deviceRemove']
 
 export class audio extends EventsViaPoll {
-	constructor () { super(validEvents) }
+	constructor() { super(validEvents) }
 
-	get devices () {
+	get devices() {
 		return [
 			...Globals.audioDevices.playback,
 			...Globals.audioDevices.recording,
 		]
 	}
 
-	openDevice (device, options = {}) {
+	openDevice(device, options = {}) {
 		return device.type === 'recording'
 			? new AudioRecordingInstance(device, options)
 			: new AudioPlaybackInstance(device, options)
 	}
 
-	bytesPerSample (format) { return AudioFormatHelpers[format].bytesPerSample }
-	minSampleValue (format) { return AudioFormatHelpers[format].minSampleValue }
-	maxSampleValue (format) { return AudioFormatHelpers[format].maxSampleValue }
-	zeroSampleValue (format) { return AudioFormatHelpers[format].zeroSampleValue }
+	bytesPerSample(format) { return AudioFormatHelpers[format].bytesPerSample }
+	minSampleValue(format) { return AudioFormatHelpers[format].minSampleValue }
+	maxSampleValue(format) { return AudioFormatHelpers[format].maxSampleValue }
+	zeroSampleValue(format) { return AudioFormatHelpers[format].zeroSampleValue }
 
-	readSample (format, buffer, offset) {
+	readSample(format, buffer, offset) {
 		return AudioFormatHelpers[format].reader.call(buffer, offset)
 	}
 
-	readerName (format) {
+	readerName(format) {
 		return AudioFormatHelpers[format].readerName
 	}
 
-	writeSample (format, buffer, value, offset) {
+	writeSample(format, buffer, value, offset) {
 		return AudioFormatHelpers[format].writer.call(buffer, value, offset)
 	}
 
-	writerName (format) {
+	writerName(format) {
 		return AudioFormatHelpers[format].writerName
 	}
 }

--- a/src/javascript/audio/prevent-exit.js
+++ b/src/javascript/audio/prevent-exit.js
@@ -1,6 +1,6 @@
-import Globals from '../globals'
+import * as Globals from '../globals.js'
 
-import { AudioPlaybackInstance } from './audio-playback-instance'
+import { AudioPlaybackInstance } from './audio-playback-instance.js'
 
 let timeout
 

--- a/src/javascript/audio/prevent-exit.js
+++ b/src/javascript/audio/prevent-exit.js
@@ -1,5 +1,7 @@
+// TODO: handle import issues here
+
 const Globals = require('../globals')
-const { AudioPlaybackInstance } = require('./audio-playback-instance')
+const { AudioPlaybackInstance } = require('./audio-playback-instance').default
 
 let timeout
 

--- a/src/javascript/audio/prevent-exit.js
+++ b/src/javascript/audio/prevent-exit.js
@@ -1,7 +1,6 @@
-// TODO: handle import issues here
+import Globals from '../globals'
 
-const Globals = require('../globals')
-const { AudioPlaybackInstance } = require('./audio-playback-instance').default
+import { AudioPlaybackInstance } from './audio-playback-instance'
 
 let timeout
 

--- a/src/javascript/audio/prevent-exit.js
+++ b/src/javascript/audio/prevent-exit.js
@@ -4,7 +4,7 @@ import { AudioPlaybackInstance } from './audio-playback-instance.js'
 
 let timeout
 
-const resetTimeout = () => {
+export const resetTimeout = () => {
 	if (timeout) {
 		clearTimeout(timeout)
 		timeout = null
@@ -32,4 +32,3 @@ process.on('beforeExit', (code) => {
 	}
 })
 
-module.exports = { resetTimeout }

--- a/src/javascript/bindings.js
+++ b/src/javascript/bindings.js
@@ -2,6 +2,11 @@ import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const path = resolve(__dirname, '../../dist/sdl.node')
-console.log(path)
 
-export default await import(path)
+// Current Node.js doesn't support import a c++ addon with "import" syntax,
+// so we need to use "require" as a workaround.
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+const nativeBindings = require(path)
+
+export default nativeBindings

--- a/src/javascript/bindings.js
+++ b/src/javascript/bindings.js
@@ -1,5 +1,7 @@
-const Path = require('path')
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
-const path = Path.resolve(__dirname, '../../dist/sdl.node')
+const path = resolve(__dirname, '../../dist/sdl.node')
 
-module.exports = require(path)
+export default require(path)

--- a/src/javascript/bindings.js
+++ b/src/javascript/bindings.js
@@ -1,7 +1,7 @@
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
-
 const path = resolve(__dirname, '../../dist/sdl.node')
+console.log(path)
 
-export default require(path)
+export default await import(path)

--- a/src/javascript/cleanup.js
+++ b/src/javascript/cleanup.js
@@ -1,30 +1,30 @@
-const Bindings = require('./bindings')
-const Globals = require('./globals')
+import { cleanup } from './bindings'
+import { events, windows, audioInstances, joystickInstances, controllerInstances } from './globals'
 
 process.on('exit', (code) => {
 	if (code !== 0) { return }
 
-	Globals.events.stopPolling()
+	events.stopPolling()
 
 	// Close all windows
-	for (const window of Globals.windows.all.values()) {
+	for (const window of windows.all.values()) {
 		window.destroy()
 	}
 
 	// Close all audio instances
-	for (const instance of Globals.audioInstances.values()) {
+	for (const instance of audioInstances.values()) {
 		instance.close()
 	}
 
 	// Close all joysticks
-	for (const joystick of Globals.joystickInstances.all.values()) {
+	for (const joystick of joystickInstances.all.values()) {
 		joystick.close()
 	}
 
 	// Close all controllers
-	for (const controller of Globals.controllerInstances.all.values()) {
+	for (const controller of controllerInstances.all.values()) {
 		controller.close()
 	}
 
-	Bindings.cleanup()
+	cleanup()
 })

--- a/src/javascript/cleanup.js
+++ b/src/javascript/cleanup.js
@@ -1,4 +1,4 @@
-// TODO: import { cleanup } from './bindings.js'
+import Bindings from './bindings.js'
 import { events, windows, audioInstances, joystickInstances, controllerInstances } from './globals.js'
 
 process.on('exit', (code) => {
@@ -26,5 +26,5 @@ process.on('exit', (code) => {
 		controller.close()
 	}
 
-	cleanup()
+	Bindings.cleanup()
 })

--- a/src/javascript/cleanup.js
+++ b/src/javascript/cleanup.js
@@ -1,5 +1,5 @@
-import { cleanup } from './bindings'
-import { events, windows, audioInstances, joystickInstances, controllerInstances } from './globals'
+// TODO: import { cleanup } from './bindings.js'
+import { events, windows, audioInstances, joystickInstances, controllerInstances } from './globals.js'
 
 process.on('exit', (code) => {
 	if (code !== 0) { return }

--- a/src/javascript/clipboard/index.js
+++ b/src/javascript/clipboard/index.js
@@ -1,18 +1,14 @@
-// TODO: handle import issues here
+import * as Bindings from '../bindings'
+import { EventsViaPoll } from '../events/events-via-poll'
 
-const Bindings = require('../bindings').default
-const { EventsViaPoll } = require('../events/events-via-poll').default
+const validEvents = ['update']
 
-const validEvents = [ 'update' ]
+export class clipboard extends EventsViaPoll {
+	constructor() { super(validEvents) }
 
-const clipboard = new class extends EventsViaPoll {
-	constructor () { super(validEvents) }
-
-	get text () { return Bindings.clipboard_getText() ?? '' }
-	setText (text) {
+	get text() { return Bindings.clipboard_getText() ?? '' }
+	setText(text) {
 		if (typeof text !== 'string') { throw Object.assign(new Error("text must be a string"), { text }) }
 		Bindings.clipboard_setText(text)
 	}
-}()
-
-module.exports = { clipboard }
+}

--- a/src/javascript/clipboard/index.js
+++ b/src/javascript/clipboard/index.js
@@ -1,5 +1,5 @@
-import * as Bindings from '../bindings'
-import { EventsViaPoll } from '../events/events-via-poll'
+import * as Bindings from '../bindings.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
 
 const validEvents = ['update']
 

--- a/src/javascript/clipboard/index.js
+++ b/src/javascript/clipboard/index.js
@@ -3,7 +3,7 @@ import { EventsViaPoll } from '../events/events-via-poll.js'
 
 const validEvents = ['update']
 
-export class clipboard extends EventsViaPoll {
+export class ClipboardEventsPoll extends EventsViaPoll {
 	constructor() { super(validEvents) }
 
 	get text() { return Bindings.clipboard_getText() ?? '' }
@@ -12,3 +12,4 @@ export class clipboard extends EventsViaPoll {
 		Bindings.clipboard_setText(text)
 	}
 }
+export const clipboard = new ClipboardEventsPoll()

--- a/src/javascript/clipboard/index.js
+++ b/src/javascript/clipboard/index.js
@@ -1,5 +1,7 @@
-const Bindings = require('../bindings')
-const { EventsViaPoll } = require('../events/events-via-poll')
+// TODO: handle import issues here
+
+const Bindings = require('../bindings').default
+const { EventsViaPoll } = require('../events/events-via-poll').default
 
 const validEvents = [ 'update' ]
 

--- a/src/javascript/controller/controller-instance.js
+++ b/src/javascript/controller/controller-instance.js
@@ -1,7 +1,7 @@
-const Bindings = require('../bindings').default
-const Enums = require('../enums').default
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll').default
+import Bindings from '../bindings.js'
+import * as Globals from '../globals.js'
+import Enums from '../enums.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
 
 const validEvents = [
 	'axisMotion',
@@ -11,7 +11,7 @@ const validEvents = [
 	'close',
 ]
 
-class ControllerInstance extends EventsViaPoll {
+export class ControllerInstance extends EventsViaPoll {
 	constructor (device) {
 		super(validEvents)
 
@@ -112,4 +112,3 @@ class ControllerInstance extends EventsViaPoll {
 	}
 }
 
-module.exports = { ControllerInstance }

--- a/src/javascript/controller/controller-instance.js
+++ b/src/javascript/controller/controller-instance.js
@@ -1,7 +1,7 @@
-const Bindings = require('../bindings')
-const Enums = require('../enums')
+const Bindings = require('../bindings').default
+const Enums = require('../enums').default
 const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
+const { EventsViaPoll } = require('../events/events-via-poll').default
 
 const validEvents = [
 	'axisMotion',

--- a/src/javascript/controller/device.js
+++ b/src/javascript/controller/device.js
@@ -1,4 +1,3 @@
-
 const make = (device) => {
 	delete device.type
 	delete device.isController

--- a/src/javascript/controller/device.js
+++ b/src/javascript/controller/device.js
@@ -1,14 +1,8 @@
-const make = (device) => {
+export const make = (device) => {
 	delete device.type
 	delete device.isController
 }
 
-const compare = (a, b) => a.id - b.id
+export const compare = (a, b) => a.id - b.id
 
-const filter = (device) => device.isController
-
-export default {
-	make,
-	compare,
-	filter,
-}
+export const filter = (device) => device.isController

--- a/src/javascript/controller/device.js
+++ b/src/javascript/controller/device.js
@@ -8,7 +8,7 @@ const compare = (a, b) => a.id - b.id
 
 const filter = (device) => device.isController
 
-module.exports = {
+export default {
 	make,
 	compare,
 	filter,

--- a/src/javascript/controller/index.js
+++ b/src/javascript/controller/index.js
@@ -5,7 +5,7 @@ import { ControllerInstance } from './controller-instance.js'
 
 const validEvents = ['deviceAdd', 'deviceRemove', 'deviceRemap']
 
-export class controller extends EventsViaPoll {
+export class ControllerEventsPoll extends EventsViaPoll {
 	constructor() { super(validEvents) }
 
 	get devices() { return Globals.controllerDevices }
@@ -21,3 +21,5 @@ export class controller extends EventsViaPoll {
 		Bindings.controller_addMappings(mappings)
 	}
 }
+
+export const controller = new ControllerEventsPoll()

--- a/src/javascript/controller/index.js
+++ b/src/javascript/controller/index.js
@@ -1,6 +1,6 @@
-const Bindings = require('../bindings')
+const Bindings = require('../bindings').default
 const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
+const { EventsViaPoll } = require('../events/events-via-poll').default
 const { ControllerInstance } = require('./controller-instance')
 
 const validEvents = [ 'deviceAdd', 'deviceRemove', 'deviceRemap' ]

--- a/src/javascript/controller/index.js
+++ b/src/javascript/controller/index.js
@@ -1,18 +1,18 @@
-const Bindings = require('../bindings').default
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll').default
-const { ControllerInstance } = require('./controller-instance')
+import Bindings from '../bindings.js'
+import * as Globals from '../globals.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
+import { ControllerInstance } from './controller-instance.js'
 
-const validEvents = [ 'deviceAdd', 'deviceRemove', 'deviceRemap' ]
+const validEvents = ['deviceAdd', 'deviceRemove', 'deviceRemap']
 
 export class controller extends EventsViaPoll {
-	constructor () { super(validEvents) }
+	constructor() { super(validEvents) }
 
-	get devices () { return Globals.controllerDevices }
+	get devices() { return Globals.controllerDevices }
 
-	openDevice (device) { return new ControllerInstance(device) }
+	openDevice(device) { return new ControllerInstance(device) }
 
-	addMappings (mappings) {
+	addMappings(mappings) {
 		if (!Array.isArray(mappings)) { throw Object.assign(new Error("mappings must be an array"), { mappings }) }
 		for (const mapping of mappings) {
 			if (typeof mapping !== 'string') { throw Object.assign(new Error("mapping must be a string"), { mappings }) }

--- a/src/javascript/controller/index.js
+++ b/src/javascript/controller/index.js
@@ -5,7 +5,7 @@ const { ControllerInstance } = require('./controller-instance')
 
 const validEvents = [ 'deviceAdd', 'deviceRemove', 'deviceRemap' ]
 
-const controller = new class extends EventsViaPoll {
+export class controller extends EventsViaPoll {
 	constructor () { super(validEvents) }
 
 	get devices () { return Globals.controllerDevices }
@@ -20,6 +20,4 @@ const controller = new class extends EventsViaPoll {
 
 		Bindings.controller_addMappings(mappings)
 	}
-}()
-
-module.exports = { controller }
+}

--- a/src/javascript/enums.js
+++ b/src/javascript/enums.js
@@ -1,10 +1,14 @@
-import { getEnums } from './bindings'
-
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const path = resolve(__dirname, '../../dist/sdl.node')
+console.log(path)
+// TODO:  import { getEnums } from './bindings.js'
 const enums = getEnums()
 
-for (const [ key, obj ] of Object.entries(enums)) {
+for (const [key, obj] of Object.entries(enums)) {
 	const names = {}
-	for (const [ name, value ] of Object.entries(obj)) {
+	for (const [name, value] of Object.entries(obj)) {
 		names[value] = name
 	}
 	enums[`${key}Names`] = names

--- a/src/javascript/enums.js
+++ b/src/javascript/enums.js
@@ -1,5 +1,4 @@
 import Bindings from './bindings.js'
-console.log(Bindings.getEnums)
 const enums = Bindings.getEnums()
 
 for (const [key, obj] of Object.entries(enums)) {

--- a/src/javascript/enums.js
+++ b/src/javascript/enums.js
@@ -1,10 +1,6 @@
-import { resolve, dirname } from 'path'
-import { fileURLToPath } from 'url'
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const path = resolve(__dirname, '../../dist/sdl.node')
-console.log(path)
-// TODO:  import { getEnums } from './bindings.js'
-const enums = getEnums()
+import Bindings from './bindings.js'
+console.log(Bindings.getEnums)
+const enums = Bindings.getEnums()
 
 for (const [key, obj] of Object.entries(enums)) {
 	const names = {}

--- a/src/javascript/enums.js
+++ b/src/javascript/enums.js
@@ -1,6 +1,6 @@
-const Bindings = require('./bindings')
+import { getEnums } from './bindings'
 
-const enums = Bindings.getEnums()
+const enums = getEnums()
 
 for (const [ key, obj ] of Object.entries(enums)) {
 	const names = {}
@@ -10,4 +10,4 @@ for (const [ key, obj ] of Object.entries(enums)) {
 	enums[`${key}Names`] = names
 }
 
-module.exports = enums
+export default enums

--- a/src/javascript/events/events-via-poll.js
+++ b/src/javascript/events/events-via-poll.js
@@ -4,10 +4,10 @@ import { events } from '../globals.js'
 let _ID = 0
 const activeEmitters = new Set()
 
-const commonEvents = [ 'newListener', 'removeListener', '*' ]
+const commonEvents = ['newListener', 'removeListener', '*']
 
 export class EventsViaPoll extends EventEmitter {
-	constructor (validEvents) {
+	constructor(validEvents) {
 		super()
 
 		this._validEvents = validEvents
@@ -45,7 +45,7 @@ export class EventsViaPoll extends EventEmitter {
 		})
 	}
 
-	emit (type, ...args) {
+	emit(type, ...args) {
 		const isCommon = commonEvents.includes(type)
 		const isValid = this._validEvents.includes(type)
 		if (!isCommon && !isValid) {

--- a/src/javascript/events/events-via-poll.js
+++ b/src/javascript/events/events-via-poll.js
@@ -1,5 +1,5 @@
-const { EventEmitter } = require('events')
-const Globals = require('../globals')
+import { EventEmitter } from 'events'
+import { events } from '../globals'
 
 let _ID = 0
 const activeEmitters = new Set()
@@ -27,7 +27,7 @@ class EventsViaPoll extends EventEmitter {
 			activeEmitters.delete(id)
 			if (activeEmitters.size !== 0) { return }
 
-			Globals.events.stopPolling()
+			events.stopPolling()
 		})
 
 		this.on('newListener', (type) => {
@@ -41,7 +41,7 @@ class EventsViaPoll extends EventEmitter {
 			activeEmitters.add(id)
 			if (activeEmitters.size !== 1) { return }
 
-			Globals.events.startPolling()
+			events.startPolling()
 		})
 	}
 
@@ -60,4 +60,4 @@ class EventsViaPoll extends EventEmitter {
 	}
 }
 
-module.exports = { EventsViaPoll }
+export default { EventsViaPoll }

--- a/src/javascript/events/events-via-poll.js
+++ b/src/javascript/events/events-via-poll.js
@@ -1,12 +1,12 @@
 import { EventEmitter } from 'events'
-import { events } from '../globals'
+import { events } from '../globals.js'
 
 let _ID = 0
 const activeEmitters = new Set()
 
 const commonEvents = [ 'newListener', 'removeListener', '*' ]
 
-export default class EventsViaPoll extends EventEmitter {
+export class EventsViaPoll extends EventEmitter {
 	constructor (validEvents) {
 		super()
 

--- a/src/javascript/events/events-via-poll.js
+++ b/src/javascript/events/events-via-poll.js
@@ -6,7 +6,7 @@ const activeEmitters = new Set()
 
 const commonEvents = [ 'newListener', 'removeListener', '*' ]
 
-class EventsViaPoll extends EventEmitter {
+export default class EventsViaPoll extends EventEmitter {
 	constructor (validEvents) {
 		super()
 
@@ -60,4 +60,3 @@ class EventsViaPoll extends EventEmitter {
 	}
 }
 
-export default { EventsViaPoll }

--- a/src/javascript/events/index.js
+++ b/src/javascript/events/index.js
@@ -380,7 +380,8 @@ const stopPolling = () => {
 	eventsInterval = null
 }
 
-Globals.events = {
+Object.assign(Globals.events, {
 	startPolling,
 	stopPolling,
-}
+})
+

--- a/src/javascript/events/index.js
+++ b/src/javascript/events/index.js
@@ -1,25 +1,25 @@
-const Bindings = require('../bindings').default
-const Globals = require('../globals')
-const Enums = require('../enums').default
-const { maybeTriggerQuit } = require('./quit').default
-const { mapping } = require('../keyboard/key-mapping')
-const { joystick: joystickModule } = require('../joystick').default
-const { controller: controllerModule } = require('../controller')
-const { audio: audioModule } = require('../audio')
-const { clipboard: clipboardModule } = require('../clipboard')
-const {
-	make: makeJoystickDevice,
-	compare: compareJoystickDevice,
-} = require('../joystick/device').default
-const {
-	make: makeControllerDevice,
-	compare: compareControllerDevice,
-	filter: filterControllerDevice,
-} = require('../controller/device').default
-const {
-	make: makeAudioDevice,
-	compare: compareAudioDevice,
-} = require('../audio/device').default
+import Bindings from '../bindings.js'
+import * as Globals from '../globals.js'
+import Enums from '../enums.js'
+import { maybeTriggerQuit } from './quit.js'
+import { mapping } from '../keyboard/key-mapping.js'
+import { joystick as joystickModule } from '../joystick/index.js'
+import { controller as controllerModule } from '../controller/index.js'
+import { audio as audioModule } from '../audio/index.js'
+import { clipboard as clipboardModule } from '../clipboard/index.js'
+import {
+	make as makeJoystickDevice,
+	compare as compareJoystickDevice,
+} from '../joystick/device.js'
+import {
+	make as makeControllerDevice,
+	compare as compareControllerDevice,
+	filter as filterControllerDevice,
+} from '../controller/device.js'
+import {
+	make as makeAudioDevice,
+	compare as compareAudioDevice,
+} from '../audio/device.js'
 
 
 const reconcileDevices = (emitter, mainList, currList, compare) => {
@@ -52,7 +52,7 @@ const reconcileDevices = (emitter, mainList, currList, compare) => {
 
 	if (mainIndex < mainList.length) {
 		while (mainIndex < mainList.length) {
-			[ mainDevice ] = mainList.splice(mainIndex, 1)
+			[mainDevice] = mainList.splice(mainIndex, 1)
 			const type = 'deviceRemove'
 			const event = { type, device: mainDevice }
 			emitter.emit(type, event)

--- a/src/javascript/events/index.js
+++ b/src/javascript/events/index.js
@@ -1,25 +1,25 @@
-const Bindings = require('../bindings')
+const Bindings = require('../bindings').default
 const Globals = require('../globals')
-const Enums = require('../enums')
-const { maybeTriggerQuit } = require('./quit')
+const Enums = require('../enums').default
+const { maybeTriggerQuit } = require('./quit').default
 const { mapping } = require('../keyboard/key-mapping')
-const { joystick: joystickModule } = require('../joystick')
+const { joystick: joystickModule } = require('../joystick').default
 const { controller: controllerModule } = require('../controller')
 const { audio: audioModule } = require('../audio')
 const { clipboard: clipboardModule } = require('../clipboard')
 const {
 	make: makeJoystickDevice,
 	compare: compareJoystickDevice,
-} = require('../joystick/device')
+} = require('../joystick/device').default
 const {
 	make: makeControllerDevice,
 	compare: compareControllerDevice,
 	filter: filterControllerDevice,
-} = require('../controller/device')
+} = require('../controller/device').default
 const {
 	make: makeAudioDevice,
 	compare: compareAudioDevice,
-} = require('../audio/device')
+} = require('../audio/device').default
 
 
 const reconcileDevices = (emitter, mainList, currList, compare) => {

--- a/src/javascript/events/quit.js
+++ b/src/javascript/events/quit.js
@@ -1,9 +1,9 @@
-const Globals = require('../globals')
-const { sdl } = require('../sdl')
+import { windows } from '../globals'
+import { sdl } from '../sdl'
 
 
 const maybeTriggerQuit = () => {
-	if (Globals.windows.all.size > 0) { return }
+	if (windows.all.size > 0) { return }
 
 	let shouldPrevent = false
 	const prevent = () => { shouldPrevent = true }
@@ -20,4 +20,4 @@ const maybeTriggerQuit = () => {
 	process.exit()
 }
 
-module.exports = { maybeTriggerQuit }
+export default { maybeTriggerQuit }

--- a/src/javascript/events/quit.js
+++ b/src/javascript/events/quit.js
@@ -1,8 +1,8 @@
-import { windows } from '../globals'
-import { sdl } from '../sdl'
+import { windows } from '../globals.js'
+import { sdl } from '../sdl.js'
 
 
-const maybeTriggerQuit = () => {
+export const maybeTriggerQuit = () => {
 	if (windows.all.size > 0) { return }
 
 	let shouldPrevent = false
@@ -19,5 +19,3 @@ const maybeTriggerQuit = () => {
 	sdl.emit(type2, event2)
 	process.exit()
 }
-
-export default { maybeTriggerQuit }

--- a/src/javascript/globals.js
+++ b/src/javascript/globals.js
@@ -18,4 +18,6 @@ export const controllerInstances = {
 	all: new Set(),
 	byId: new Map(),
 };
-export const events = null;
+export let events = {
+	
+};

--- a/src/javascript/globals.js
+++ b/src/javascript/globals.js
@@ -1,25 +1,21 @@
-
-module.exports = {
-	windows: {
-		all: new Map(),
-		focused: null,
-		hovered: null,
-	},
-	audioDevices: {
-		playback: [],
-		recording: [],
-	},
-	audioInstances: new Map(),
-	joystickDevices: [],
-	joystickInstances: {
-		all: new Set(),
-		byId: new Map(),
-	},
-	controllerDevices: [],
-	controllerInstances: {
-		all: new Set(),
-		byId: new Map(),
-	},
-
-	events: null, // Set later to { startPolling, stopPolling }
-}
+export const windows = {
+	all: new Map(),
+	focused: null,
+	hovered: null,
+};
+export const audioDevices = {
+	playback: [],
+	recording: [],
+};
+export const audioInstances = new Map();
+export const joystickDevices = [];
+export const joystickInstances = {
+	all: new Set(),
+	byId: new Map(),
+};
+export const controllerDevices = [];
+export const controllerInstances = {
+	all: new Set(),
+	byId: new Map(),
+};
+export const events = null;

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -1,13 +1,6 @@
 import { isMainThread } from 'worker_threads'
-if (!isMainThread) {
-  throw new Error('@kmamal/sdl can only be used in the main thread')
-}
+import Bindings from './bindings.js'
 
-import { initialize } from './bindings.js'
-
-const info = initialize()
-
-import { sdl } from './sdl.js'
 import { video } from './video/index.js'
 import { keyboard } from './keyboard/index.js'
 import { mouse } from './mouse/index.js'
@@ -16,17 +9,23 @@ import { controller } from './controller/index.js'
 import { audio } from './audio/index.js'
 import { clipboard } from './clipboard/index.js'
 
-sdl.info = info
-sdl.video = video
-sdl.keyboard = keyboard
-sdl.mouse = mouse
-sdl.joystick = joystick
-sdl.controller = controller
-sdl.audio = audio
-sdl.clipboard = clipboard
-
 import './events/index.js'
 import './audio/prevent-exit.js'
 import './cleanup.js'
 
-export default sdl
+if (!isMainThread) {
+  throw new Error('@kmamal/sdl can only be used in the main thread')
+}
+
+const info = Bindings.initialize()
+
+export {
+  info,
+  video,
+  keyboard,
+  mouse,
+  joystick,
+  controller,
+  audio,
+  clipboard,
+}

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -3,18 +3,18 @@ if (!isMainThread) {
   throw new Error('@kmamal/sdl can only be used in the main thread')
 }
 
-import { initialize } from './bindings'
+import { initialize } from './bindings.js'
 
 const info = initialize()
 
-import { sdl } from './sdl'
-import { video } from './video'
-import { keyboard } from './keyboard'
-import { mouse } from './mouse'
-import { joystick } from './joystick'
-import { controller } from './controller'
-import { audio } from './audio'
-import { clipboard } from './clipboard'
+import { sdl } from './sdl.js'
+import { video } from './video/index.js'
+import { keyboard } from './keyboard/index.js'
+import { mouse } from './mouse/index.js'
+import { joystick } from './joystick/index.js'
+import { controller } from './controller/index.js'
+import { audio } from './audio/index.js'
+import { clipboard } from './clipboard/index.js'
 
 sdl.info = info
 sdl.video = video
@@ -25,8 +25,8 @@ sdl.controller = controller
 sdl.audio = audio
 sdl.clipboard = clipboard
 
-import './events'
-import './audio/prevent-exit'
-import './cleanup'
+import './events/index.js'
+import './audio/prevent-exit.js'
+import './cleanup.js'
 
 export default sdl

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -1,18 +1,20 @@
-const { isMainThread } = require('worker_threads')
-if (!isMainThread) { throw new Error('@kmamal/sdl can only be used in the main thread') }
+import { isMainThread } from 'worker_threads'
+if (!isMainThread) {
+  throw new Error('@kmamal/sdl can only be used in the main thread')
+}
 
-const Bindings = require('./bindings')
+import { initialize } from './bindings'
 
-const info = Bindings.initialize()
+const info = initialize()
 
-const { sdl } = require('./sdl')
-const { video } = require('./video')
-const { keyboard } = require('./keyboard')
-const { mouse } = require('./mouse')
-const { joystick } = require('./joystick')
-const { controller } = require('./controller')
-const { audio } = require('./audio')
-const { clipboard } = require('./clipboard')
+import { sdl } from './sdl'
+import { video } from './video'
+import { keyboard } from './keyboard'
+import { mouse } from './mouse'
+import { joystick } from './joystick'
+import { controller } from './controller'
+import { audio } from './audio'
+import { clipboard } from './clipboard'
 
 sdl.info = info
 sdl.video = video
@@ -23,8 +25,8 @@ sdl.controller = controller
 sdl.audio = audio
 sdl.clipboard = clipboard
 
-require('./events')
-require('./audio/prevent-exit')
-require('./cleanup')
+import './events'
+import './audio/prevent-exit'
+import './cleanup'
 
-module.exports = sdl
+export default sdl

--- a/src/javascript/joystick/device.js
+++ b/src/javascript/joystick/device.js
@@ -1,4 +1,4 @@
-const Enums = require('../enums')
+import Enums from '../enums'
 
 const make = (device) => {
 	const { type } = device
@@ -9,7 +9,7 @@ const make = (device) => {
 
 const compare = (a, b) => a.id - b.id
 
-module.exports = {
+export default {
 	make,
 	compare,
 }

--- a/src/javascript/joystick/device.js
+++ b/src/javascript/joystick/device.js
@@ -1,15 +1,10 @@
-import Enums from '../enums'
+import Enums from '../enums.js'
 
-const make = (device) => {
+export const make = (device) => {
 	const { type } = device
 	device.type = Enums.joystickTypeNames[type]
 	delete device.isController
 	delete device.mapping
 }
 
-const compare = (a, b) => a.id - b.id
-
-export default {
-	make,
-	compare,
-}
+export const compare = (a, b) => a.id - b.id

--- a/src/javascript/joystick/index.js
+++ b/src/javascript/joystick/index.js
@@ -4,10 +4,11 @@ import { JoystickInstance } from './joystick-instance.js'
 
 const validEvents = ['deviceAdd', 'deviceRemove']
 
-export class joystick extends EventsViaPoll {
+class JoystickEventsPoll extends EventsViaPoll {
 	constructor() { super(validEvents) }
 
 	get devices() { return joystickDevices }
 
 	openDevice(device) { return new JoystickInstance(device) }
 }
+export const joystick = new JoystickEventsPoll()

--- a/src/javascript/joystick/index.js
+++ b/src/javascript/joystick/index.js
@@ -1,15 +1,13 @@
-import { joystickDevices } from '../globals'
-import { EventsViaPoll } from '../events/events-via-poll'
-import { JoystickInstance } from './joystick-instance'
+import { joystickDevices } from '../globals.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
+import { JoystickInstance } from './joystick-instance.js'
 
-const validEvents = [ 'deviceAdd', 'deviceRemove' ]
+const validEvents = ['deviceAdd', 'deviceRemove']
 
-const joystick = new class extends EventsViaPoll {
-	constructor () { super(validEvents) }
+export class joystick extends EventsViaPoll {
+	constructor() { super(validEvents) }
 
-	get devices () { return joystickDevices }
+	get devices() { return joystickDevices }
 
-	openDevice (device) { return new JoystickInstance(device) }
-}()
-
-export default { joystick }
+	openDevice(device) { return new JoystickInstance(device) }
+}

--- a/src/javascript/joystick/index.js
+++ b/src/javascript/joystick/index.js
@@ -1,15 +1,15 @@
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
-const { JoystickInstance } = require('./joystick-instance')
+import { joystickDevices } from '../globals'
+import { EventsViaPoll } from '../events/events-via-poll'
+import { JoystickInstance } from './joystick-instance'
 
 const validEvents = [ 'deviceAdd', 'deviceRemove' ]
 
 const joystick = new class extends EventsViaPoll {
 	constructor () { super(validEvents) }
 
-	get devices () { return Globals.joystickDevices }
+	get devices () { return joystickDevices }
 
 	openDevice (device) { return new JoystickInstance(device) }
 }()
 
-module.exports = { joystick }
+export default { joystick }

--- a/src/javascript/joystick/joystick-instance.js
+++ b/src/javascript/joystick/joystick-instance.js
@@ -1,7 +1,7 @@
-const Bindings = require('../bindings').default
-const Enums = require('../enums').default
-const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll').default
+import Bindings from '../bindings.js'
+import Enums from '../enums.js'
+import * as Globals from '../globals.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
 
 const validEvents = [
 	'axisMotion',
@@ -12,8 +12,8 @@ const validEvents = [
 	'close',
 ]
 
-class JoystickInstance extends EventsViaPoll {
-	constructor (device) {
+export class JoystickInstance extends EventsViaPoll {
+	constructor(device) {
 		super(validEvents)
 
 		const result = Bindings.joystick_open(device._index)
@@ -41,22 +41,22 @@ class JoystickInstance extends EventsViaPoll {
 		collection.add(this)
 	}
 
-	get device () { return this._device }
-	get firmwareVersion () { return this._firmwareVersion }
-	get serialNumber () { return this._serialNumber }
+	get device() { return this._device }
+	get firmwareVersion() { return this._firmwareVersion }
+	get serialNumber() { return this._serialNumber }
 
-	get axes () { return this._axes }
-	get balls () { return this._balls }
-	get buttons () { return this._buttons }
-	get hats () { return this._hats }
+	get axes() { return this._axes }
+	get balls() { return this._balls }
+	get buttons() { return this._buttons }
+	get hats() { return this._hats }
 
-	get power () {
+	get power() {
 		const power = Bindings.joystick_getPower(this._device.id)
 		return Enums.powerLevelNames[power]
 	}
 
-	get hasLed () { return this._hasLed }
-	setLed (red, green, blue) {
+	get hasLed() { return this._hasLed }
+	setLed(red, green, blue) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._device.id }) }
 
 		if (!Number.isFinite(red)) { throw Object.assign(new Error("red must be a number"), { red }) }
@@ -69,8 +69,8 @@ class JoystickInstance extends EventsViaPoll {
 		Bindings.joystick_rumble(this._device.id, red, green, blue)
 	}
 
-	get hasRumble () { return this._hasRumble }
-	rumble (lowFreqRumble = 1, highFreqRumble = 1, duration = 1e3) {
+	get hasRumble() { return this._hasRumble }
+	rumble(lowFreqRumble = 1, highFreqRumble = 1, duration = 1e3) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._device.id }) }
 
 		if (!Number.isFinite(lowFreqRumble)) { throw Object.assign(new Error("lowFreqRumble must be a number"), { lowFreqRumble }) }
@@ -82,10 +82,10 @@ class JoystickInstance extends EventsViaPoll {
 		Bindings.joystick_rumble(this._device.id, lowFreqRumble, highFreqRumble, duration)
 	}
 
-	stopRumble () { this.rumble(0, 0) }
+	stopRumble() { this.rumble(0, 0) }
 
-	get hasRumbleTriggers () { return this._hasRumbleTriggers }
-	rumbleTriggers (leftRumble = 1, rightRumble = 1, duration = 1e3) {
+	get hasRumbleTriggers() { return this._hasRumbleTriggers }
+	rumbleTriggers(leftRumble = 1, rightRumble = 1, duration = 1e3) {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._device.id }) }
 
 		if (!Number.isFinite(leftRumble)) { throw Object.assign(new Error("leftRumble must be a number"), { leftRumble }) }
@@ -97,10 +97,10 @@ class JoystickInstance extends EventsViaPoll {
 		Bindings.joystick_rumbleTriggers(this._device.id, leftRumble, rightRumble, duration)
 	}
 
-	stopRumbleTriggers () { this.rumbleTriggers(0, 0) }
+	stopRumbleTriggers() { this.rumbleTriggers(0, 0) }
 
-	get closed () { return this._closed }
-	close () {
+	get closed() { return this._closed }
+	close() {
 		if (this._closed) { throw Object.assign(new Error("instance is closed"), { id: this._device.id }) }
 
 		this.emit('close')
@@ -116,5 +116,3 @@ class JoystickInstance extends EventsViaPoll {
 		}
 	}
 }
-
-module.exports = { JoystickInstance }

--- a/src/javascript/joystick/joystick-instance.js
+++ b/src/javascript/joystick/joystick-instance.js
@@ -1,7 +1,7 @@
-const Bindings = require('../bindings')
-const Enums = require('../enums')
+const Bindings = require('../bindings').default
+const Enums = require('../enums').default
 const Globals = require('../globals')
-const { EventsViaPoll } = require('../events/events-via-poll')
+const { EventsViaPoll } = require('../events/events-via-poll').default
 
 const validEvents = [
 	'axisMotion',

--- a/src/javascript/keyboard/index.js
+++ b/src/javascript/keyboard/index.js
@@ -1,6 +1,6 @@
-import Bindings from '../bindings'
-import Enums from '../enums'
-import { mapping, reverseMapping } from './key-mapping'
+import Bindings from '../bindings.js'
+import Enums from '../enums.js'
+import { mapping, reverseMapping } from './key-mapping.js'
 
 const keyboard = {
 	get SCANCODE () { return Enums.scancode },

--- a/src/javascript/keyboard/index.js
+++ b/src/javascript/keyboard/index.js
@@ -1,6 +1,6 @@
-const Bindings = require('../bindings')
-const Enums = require('../enums')
-const { mapping, reverseMapping } = require('./key-mapping')
+import Bindings from '../bindings'
+import Enums from '../enums'
+import { mapping, reverseMapping } from './key-mapping'
 
 const keyboard = {
 	get SCANCODE () { return Enums.scancode },
@@ -25,4 +25,4 @@ const keyboard = {
 	getState () { return Bindings.keyboard_getState() },
 }
 
-module.exports = { keyboard }
+export default { keyboard }

--- a/src/javascript/keyboard/index.js
+++ b/src/javascript/keyboard/index.js
@@ -2,7 +2,7 @@ import Bindings from '../bindings.js'
 import Enums from '../enums.js'
 import { mapping, reverseMapping } from './key-mapping.js'
 
-const keyboard = {
+export const keyboard = {
 	get SCANCODE () { return Enums.scancode },
 
 	getKey (scancode) {
@@ -24,5 +24,3 @@ const keyboard = {
 
 	getState () { return Bindings.keyboard_getState() },
 }
-
-export default { keyboard }

--- a/src/javascript/keyboard/key-mapping.js
+++ b/src/javascript/keyboard/key-mapping.js
@@ -1,4 +1,4 @@
-const Bindings = require('../bindings')
+const Bindings = require('../bindings').default
 
 const mapping = {
 	'A': 'a',

--- a/src/javascript/keyboard/key-mapping.js
+++ b/src/javascript/keyboard/key-mapping.js
@@ -1,6 +1,6 @@
-const Bindings = require('../bindings').default
+import Bindings from '../bindings.js'
 
-const mapping = {
+export const mapping = {
 	'A': 'a',
 	'AC Back': 'back',
 	'AC Bookmarks': 'bookmarks',
@@ -203,7 +203,7 @@ const mapping = {
 	'Z': 'z',
 }
 
-const reverseMapping = {}
+export const reverseMapping = {}
 
 for (const [ key, value ] of Object.entries(mapping)) {
 	const existing = reverseMapping[value]
@@ -212,9 +212,4 @@ for (const [ key, value ] of Object.entries(mapping)) {
 		Bindings.keyboard_getScancode(key),
 	)) : key
 	reverseMapping[value] = _key
-}
-
-module.exports = {
-	mapping,
-	reverseMapping,
 }

--- a/src/javascript/mouse/index.js
+++ b/src/javascript/mouse/index.js
@@ -1,7 +1,7 @@
 import Bindings from '../bindings.js'
 import Enums from '../enums.js'
 
-const mouse = {
+export const mouse = {
 	get BUTTON () { return Enums.button },
 
 	getButton (button) {
@@ -69,5 +69,3 @@ const mouse = {
 
 	uncapture () { mouse.capture(false) },
 }
-
-export default { mouse }

--- a/src/javascript/mouse/index.js
+++ b/src/javascript/mouse/index.js
@@ -1,5 +1,5 @@
-const Bindings = require('../bindings')
-const Enums = require('../enums')
+import Bindings from '../bindings'
+import Enums from '../enums'
 
 const mouse = {
 	get BUTTON () { return Enums.button },
@@ -70,4 +70,4 @@ const mouse = {
 	uncapture () { mouse.capture(false) },
 }
 
-module.exports = { mouse }
+export default { mouse }

--- a/src/javascript/mouse/index.js
+++ b/src/javascript/mouse/index.js
@@ -1,5 +1,5 @@
-import Bindings from '../bindings'
-import Enums from '../enums'
+import Bindings from '../bindings.js'
+import Enums from '../enums.js'
 
 const mouse = {
 	get BUTTON () { return Enums.button },

--- a/src/javascript/sdl.js
+++ b/src/javascript/sdl.js
@@ -1,5 +1,3 @@
-const { EventsViaPoll } = require('./events/events-via-poll')
+import { EventsViaPoll } from './events/events-via-poll'
 
-const sdl = new EventsViaPoll([ 'beforeQuit', 'quit' ])
-
-module.exports = { sdl }
+export default sdl = new EventsViaPoll(['beforeQuit', 'quit'])

--- a/src/javascript/sdl.js
+++ b/src/javascript/sdl.js
@@ -1,3 +1,3 @@
-import { EventsViaPoll } from './events/events-via-poll'
+import { EventsViaPoll } from './events/events-via-poll.js'
 
-export default sdl = new EventsViaPoll(['beforeQuit', 'quit'])
+export const sdl = new EventsViaPoll(['beforeQuit', 'quit'])

--- a/src/javascript/video/index.js
+++ b/src/javascript/video/index.js
@@ -1,7 +1,7 @@
-import Bindings from '../bindings'
-import { windows as _windows } from '../globals'
-import Enums from '../enums'
-import { Window } from './window'
+import Bindings from '../bindings.js'
+import { windows as _windows } from '../globals.js'
+import Enums from '../enums.js'
+import { Window } from './window.js'
 
 const video = {
 	get displays () {

--- a/src/javascript/video/index.js
+++ b/src/javascript/video/index.js
@@ -1,7 +1,7 @@
-const Bindings = require('../bindings')
-const Globals = require('../globals')
-const Enums = require('../enums')
-const { Window } = require('./window')
+import Bindings from '../bindings'
+import { windows as _windows } from '../globals'
+import Enums from '../enums'
+import { Window } from './window'
 
 const video = {
 	get displays () {
@@ -12,11 +12,11 @@ const video = {
 		return displays
 	},
 
-	get windows () { return [ ...Globals.windows.all.values() ] },
-	get focused () { return Globals.windows.focused },
-	get hovered () { return Globals.windows.hovered },
+	get windows () { return [ ..._windows.all.values() ] },
+	get focused () { return _windows.focused },
+	get hovered () { return _windows.hovered },
 
 	createWindow: (options) => new Window(options),
 }
 
-module.exports = { video }
+export default { video }

--- a/src/javascript/video/index.js
+++ b/src/javascript/video/index.js
@@ -3,7 +3,7 @@ import { windows as _windows } from '../globals.js'
 import Enums from '../enums.js'
 import { Window } from './window.js'
 
-const video = {
+export const video = {
 	get displays () {
 		const displays = Bindings.video_getDisplays()
 		for (const display of displays) {
@@ -18,5 +18,3 @@ const video = {
 
 	createWindow: (options) => new Window(options),
 }
-
-export default { video }

--- a/src/javascript/video/window.js
+++ b/src/javascript/video/window.js
@@ -1,8 +1,8 @@
-const Bindings = require('../bindings')
-const Globals = require('../globals')
-const Enums = require('../enums')
-const { EventsViaPoll } = require('../events/events-via-poll')
-const { maybeTriggerQuit } = require('../events/quit')
+import Bindings from '../bindings'
+import { windows } from '../globals'
+import Enums from '../enums'
+import { EventsViaPoll } from '../events/events-via-poll'
+import { maybeTriggerQuit } from '../events/quit'
 
 const validEvents = [
 	'show',
@@ -118,7 +118,7 @@ class Window extends EventsViaPoll {
 		this._maximized = false
 		this._destroyed = false
 
-		Globals.windows.all.set(this._id, this)
+		windows.all.set(this._id, this)
 
 		// This also keeps Node.js alive while windows are open
 		this.on('close', () => {
@@ -272,7 +272,7 @@ class Window extends EventsViaPoll {
 
 		Bindings.window_focus(this._id)
 		this._focused = true
-		Globals.windows.focused = this
+		windows.focused = this
 	}
 
 	get hovered () { return this._hovered }
@@ -321,16 +321,16 @@ class Window extends EventsViaPoll {
 	destroy () {
 		if (this._destroyed) { throw Object.assign(new Error("window is destroyed"), { id: this._id }) }
 
-		if (Globals.windows.hovered === this) { Globals.windows.hovered = null }
-		if (Globals.windows.focused === this) { Globals.windows.focused = null }
+		if (windows.hovered === this) { windows.hovered = null }
+		if (windows.focused === this) { windows.focused = null }
 
 		Bindings.window_destroy(this._id)
 		this._destroyed = true
 
-		Globals.windows.all.delete(this._id)
+		windows.all.delete(this._id)
 
 		maybeTriggerQuit()
 	}
 }
 
-module.exports = { Window }
+export default { Window }

--- a/src/javascript/video/window.js
+++ b/src/javascript/video/window.js
@@ -1,8 +1,8 @@
-import Bindings from '../bindings'
-import { windows } from '../globals'
-import Enums from '../enums'
-import { EventsViaPoll } from '../events/events-via-poll'
-import { maybeTriggerQuit } from '../events/quit'
+import Bindings from '../bindings.js'
+import { windows } from '../globals.js'
+import Enums from '../enums.js'
+import { EventsViaPoll } from '../events/events-via-poll.js'
+import { maybeTriggerQuit } from '../events/quit.js'
 
 const validEvents = [
 	'show',
@@ -32,7 +32,7 @@ const validEvents = [
 	'dropComplete',
 ]
 
-class Window extends EventsViaPoll {
+export class Window extends EventsViaPoll {
 	constructor (options = {}) {
 		super(validEvents)
 
@@ -332,5 +332,3 @@ class Window extends EventsViaPoll {
 		maybeTriggerQuit()
 	}
 }
-
-export default { Window }


### PR DESCRIPTION
## Proposal
Since the ecosystem of Node.js is migrating to ES modules, and V8 engine makes javascript running so fast, it's a fundamental step for building a real desktop game without browser in pure javascript/typescript.

## What I did
1. Ported all classes from commonJS to ES modules.
2. Dynamically loading the c++ addon with ES modules.
3. Made the "Hello, World!" example working with ES Modules.
4. Less breaking changes. ~~alright, cjs to mjs is an obvious breaking change~~

## What's missing
- [ ] Complete the "d.ts" file for typescript and type hints.
- [ ] Better naming and structure.
- [ ] Renew examples to fit ES Modules.
- [x] Port related projects such as "@kmamal/gl" to ES modules. kmamal/headless-gl#1

I'm happy to keep this going, so don't hesitate to ask any further questions. 😊