### PR TITLE
Allow bypassing the initial axis calibration routine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           - runner: macos-15-intel
           - runner: macos-15
           - runner: ubuntu-latest
-          - runner: ubuntu-24-arm
+          - runner: ubuntu-24.04-arm
           - runner: windows-latest
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,65 +10,32 @@ permissions:
   contents: write
 
 jobs:
-  ensure-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve release tag
-        id: release-tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Ensure release exists
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          tag="${{ steps.release-tag.outputs.tag }}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "release ${tag} already exists"
-          else
-            gh release create "$tag" --title "$tag" --prerelease
-          fi
-
-  build-and-upload:
-    needs: ensure-release
+  build:
+    name: ${{ matrix.platform.name }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: macos-15-intel
-          - runner: macos-15
-          - runner: ubuntu-latest
-          - runner: ubuntu-24.04-arm
-          - runner: windows-latest
-    runs-on: ${{ matrix.runner }}
+        platform:
+          - { name: 'Linux (x64)', os: ubuntu-latest }
+          - { name: 'Linux (arm64)', os: ubuntu-24.04-arm }
+          - { name: 'Windows (x64)', os: windows-latest }
+          - { name: 'Mac (x64)', os: macos-15-intel }
+          - { name: 'Mac (arm64)', os: macos-15 }
+    runs-on: ${{ matrix.platform.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
-      - name: Install Linux build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev
+      - if: ${{ startsWith(matrix.platform.os, 'macos-') }}
+        run: brew update && ./scripts/install-deps-mac.sh
 
-      - name: Install dependencies
-        run: npm ci
+      - if: ${{ startsWith(matrix.platform.os, 'ubuntu-') }}
+        run: sudo apt-get update && sudo ./scripts/install-deps-ubuntu.sh
 
-      - name: Build and upload release asset
-        env:
+      - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROSS_COMPILE_ARCH: ${{ matrix.platform.arch }}
         run: npm run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,68 @@
 name: Build and upload
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
 
 jobs:
-  empty:
+  ensure-release:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "empty"'
+      - name: Checkout
+        uses: actions/checkout@v4
 
-# This file is empty on the master branch. Releases are made from the 'workflow' branch.
+      - name: Resolve release tag
+        id: release-tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure release exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          tag="${{ steps.release-tag.outputs.tag }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release ${tag} already exists"
+          else
+            gh release create "$tag" --title "$tag" --prerelease
+          fi
+
+  build-and-upload:
+    needs: ensure-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+          - runner: macos-15
+          - runner: ubuntu-latest
+          - runner: ubuntu-24-arm
+          - runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and upload release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run release

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.13",
+  "version": "0.11.13-rawaxis.0",
   "name": "@kmamal/sdl",
   "description": "SDL bindings for Node.js",
   "keywords": [
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kmamal/node-sdl.git"
+    "url": "git+ssh://git@github.com/rafaellehmkuhl/node-sdl.git"
   },
   "main": "./src/javascript/index.js",
   "types": "./src/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.13-rawaxis.0",
+  "version": "0.11.13-rawaxis.1",
   "name": "@kmamal/sdl",
   "description": "SDL bindings for Node.js",
   "keywords": [

--- a/src/javascript/controller/controller-instance.js
+++ b/src/javascript/controller/controller-instance.js
@@ -13,12 +13,13 @@ const validEvents = [
 ]
 
 class ControllerInstance extends EventsViaPoll {
-	constructor (device) {
+	constructor (device, options = {}) {
 		super(validEvents)
 
 		if (!Globals.controllerDevices.includes(device)) { throw Object.assign(new Error("invalid device"), { device }) }
 
-		const result = Bindings.controller_open(device._index)
+		const { rawAxisMode = false } = options
+		const result = Bindings.controller_open(device._index, rawAxisMode)
 
 		this._firmwareVersion = result.firmwareVersion
 		this._serialNumber = result.serialNumber

--- a/src/javascript/controller/index.js
+++ b/src/javascript/controller/index.js
@@ -13,7 +13,7 @@ const controller = new class extends EventsViaPoll {
 		return Globals.controllerDevices
 	}
 
-	openDevice (device) { return new ControllerInstance(device) }
+	openDevice (device, options = {}) { return new ControllerInstance(device, options) }
 
 	addMappings (mappings) {
 		if (!Array.isArray(mappings)) { throw Object.assign(new Error("mappings must be an array"), { mappings }) }

--- a/src/javascript/joystick/index.js
+++ b/src/javascript/joystick/index.js
@@ -28,7 +28,7 @@ const joystick = new class extends EventsViaPoll {
 		return Globals.joystickDevices
 	}
 
-	openDevice (device) { return new JoystickInstance(device) }
+	openDevice (device, options = {}) { return new JoystickInstance(device, options) }
 }()
 
 module.exports = { joystick }

--- a/src/javascript/joystick/joystick-instance.js
+++ b/src/javascript/joystick/joystick-instance.js
@@ -13,12 +13,13 @@ const validEvents = [
 ]
 
 class JoystickInstance extends EventsViaPoll {
-	constructor (device) {
+	constructor (device, options = {}) {
 		super(validEvents)
 
 		if (!Globals.joystickDevices.includes(device)) { throw Object.assign(new Error("invalid device"), { device }) }
 
-		const result = Bindings.joystick_open(device._index)
+		const { rawAxisMode = false } = options
+		const result = Bindings.joystick_open(device._index, rawAxisMode)
 
 		this._firmwareVersion = result.firmwareVersion
 		this._serialNumber = result.serialNumber

--- a/src/native/controller.cpp
+++ b/src/native/controller.cpp
@@ -124,6 +124,7 @@ controller::open (const Napi::CallbackInfo &info)
 	Napi::Env env = info.Env();
 
 	int index = info[0].As<Napi::Number>().Int32Value();
+	bool rawAxisMode = info.Length() > 1 && info[1].As<Napi::Boolean>().Value();
 
 	SDL_GameController *controller = SDL_GameControllerOpen(index);
 	if (controller == nullptr) {
@@ -131,6 +132,12 @@ controller::open (const Napi::CallbackInfo &info)
 		message << "SDL_GameControllerOpen(" << index << ") error: " << SDL_GetError();
 		SDL_ClearError();
 		throw Napi::Error::New(env, message.str());
+	}
+
+	SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
+	int joystick_id = SDL_JoystickInstanceID(joystick);
+	if (rawAxisMode) {
+		joystick::rawAxisModeDevices.insert(joystick_id);
 	}
 
 	// SDL_GameControllerOpen produces errors even though it succeeds
@@ -154,7 +161,6 @@ controller::open (const Napi::CallbackInfo &info)
 
 	Napi::Value steam_handle = getSteamHandle(env, controller);
 
-	SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
 	Napi::Value power = joystick::getPowerLevel(env, joystick);
 
 	Napi::Object result = Napi::Object::New(env);
@@ -185,6 +191,10 @@ controller::close (const Napi::CallbackInfo &info)
 		SDL_ClearError();
 		throw Napi::Error::New(env, message.str());
 	}
+
+	SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
+	int joystick_id = SDL_JoystickInstanceID(joystick);
+	joystick::rawAxisModeDevices.erase(joystick_id);
 
 	SDL_GameControllerClose(controller);
 

--- a/src/native/joystick.cpp
+++ b/src/native/joystick.cpp
@@ -5,12 +5,14 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <set>
 
 
 std::map<Uint8, std::string> joystick::hat_positions;
 std::map<SDL_JoystickType, std::string> joystick::types;
 std::map<SDL_JoystickPowerLevel, std::string> joystick::power_levels;
 SDL_JoystickGUID joystick::zero_guid;
+std::set<int> joystick::rawAxisModeDevices;
 
 double
 joystick::mapAxis (SDL_Joystick *joystick, int axis) {
@@ -19,12 +21,20 @@ joystick::mapAxis (SDL_Joystick *joystick, int axis) {
 
 double
 joystick::mapAxisValue (SDL_Joystick *joystick, int axis, int value) {
-	Sint16 initial;
-	if (!SDL_JoystickGetAxisInitialState(joystick, axis, &initial)) { initial = 0; }
-	double range = value < initial
-		? initial - SDL_JOYSTICK_AXIS_MIN
-		: SDL_JOYSTICK_AXIS_MAX - initial;
-	return (value - initial) / range;
+	int joystick_id = SDL_JoystickInstanceID(joystick);
+	bool rawMode = rawAxisModeDevices.count(joystick_id) > 0;
+
+	if (!rawMode) {
+		Sint16 initial;
+		if (!SDL_JoystickGetAxisInitialState(joystick, axis, &initial)) { initial = 0; }
+		double range = value < initial
+			? initial - SDL_JOYSTICK_AXIS_MIN
+			: SDL_JOYSTICK_AXIS_MAX - initial;
+		return (value - initial) / range;
+	}
+
+	double range = value < 0 ? -SDL_JOYSTICK_AXIS_MIN : SDL_JOYSTICK_AXIS_MAX;
+	return value / range;
 }
 
 Napi::Array
@@ -176,6 +186,7 @@ joystick::open (const Napi::CallbackInfo &info)
 	Napi::Env env = info.Env();
 
 	int index = info[0].As<Napi::Number>().Int32Value();
+	bool rawAxisMode = info.Length() > 1 && info[1].As<Napi::Boolean>().Value();
 
 	SDL_Joystick *joystick = SDL_JoystickOpen(index);
 	if (joystick == nullptr) {
@@ -183,6 +194,11 @@ joystick::open (const Napi::CallbackInfo &info)
 		message << "SDL_JoystickOpen(" << index << ") error: " << SDL_GetError();
 		SDL_ClearError();
 		throw Napi::Error::New(env, message.str());
+	}
+
+	int joystick_id = SDL_JoystickInstanceID(joystick);
+	if (rawAxisMode) {
+		rawAxisModeDevices.insert(joystick_id);
 	}
 
 	// SDL_JoystickOpen produces errors even though it succeeds
@@ -419,6 +435,7 @@ joystick::close (const Napi::CallbackInfo &info)
 		throw Napi::Error::New(env, message.str());
 	}
 
+	rawAxisModeDevices.erase(joystick_id);
 	SDL_JoystickClose(joystick);
 
 	return env.Undefined();

--- a/src/native/joystick.h
+++ b/src/native/joystick.h
@@ -4,6 +4,7 @@
 #include <napi.h>
 #include <SDL.h>
 #include <map>
+#include <set>
 #include <string>
 
 namespace joystick {
@@ -12,6 +13,7 @@ namespace joystick {
 	extern std::map<Uint8, std::string> hat_positions;
 	extern std::map<SDL_JoystickPowerLevel, std::string> power_levels;
 	extern SDL_JoystickGUID zero_guid;
+	extern std::set<int> rawAxisModeDevices;
 
 	double mapAxis (SDL_Joystick *joystick, int axis);
 	double mapAxisValue (SDL_Joystick *joystick, int axis, int value);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -956,6 +956,15 @@ export namespace Sdl {
 
 	export namespace Joystick {
 
+		export interface OpenOptions {
+			/**
+			 * When true, axis values are normalized without SDL's initial state calibration.
+			 * This avoids incorrect zero-point calibration when joysticks aren't centered at startup.
+			 * @default false
+			 */
+			rawAxisMode?: boolean
+		}
+
 		export interface BallPosition {
 			readonly x: number
 			readonly y: number
@@ -1050,12 +1059,21 @@ export namespace Sdl {
 
 			readonly devices: Device[]
 
-			openDevice (device: Device): JoystickInstance
+			openDevice (device: Device, options?: OpenOptions): JoystickInstance
 		}
 
 	}
 
 	export namespace Controller {
+
+		export interface OpenOptions {
+			/**
+			 * When true, axis values are normalized without SDL's initial state calibration.
+			 * This avoids incorrect zero-point calibration when controllers aren't centered at startup.
+			 * @default false
+			 */
+			rawAxisMode?: boolean
+		}
 
 		export type ControllerType
 			= null
@@ -1190,7 +1208,7 @@ export namespace Sdl {
 
 			readonly devices: Device[]
 
-			openDevice (device: Device): ControllerInstance
+			openDevice (device: Device, options?: OpenOptions): ControllerInstance
 		}
 
 	}


### PR DESCRIPTION
This initial calibration routine appears to be happening on top of what SDL provides by default, and in our case it is causing the triggers from the users joysticks to be sending values out of the expected range.

What we saw happening was that, during startup, the joystick is usually sitting on a desk, and its unfortunately very common for the triggers to be slightly pressed, since they are usually the resting point in the back of the joystick. With them pressed during the startup, the initial calibration is seeing this press as an offset, and causing the original axis range to be modified.

The solution here is to add an extra argument during the opening of the device, which allows the user to bypass this initial calibration and take care of it from its application. The bypass is false by default, so there's no API break.

I'm open for feedback on both the feature and the implementation itself :)