### PR TITLE
update build-sdl to 2.32.70

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ sdl
 build
 dist
 publish
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kmamal/sdl",
-  "version": "0.11.13",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kmamal/sdl",
-      "version": "0.11.13",
+      "version": "0.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.13",
+  "version": "0.12.0",
   "name": "@kmamal/sdl",
   "description": "SDL bindings for Node.js",
   "keywords": [
@@ -77,7 +77,7 @@
     "sdl": {
       "owner": "kmamal",
       "repo": "build-sdl",
-      "version": "2.32.8"
+      "version": "2.32.70"
     }
   }
 }


### PR DESCRIPTION
This is based on my pull request https://github.com/kmamal/build-sdl/pull/3 and uses [sdl2-compat](https://github.com/libsdl-org/sdl2-compat) to be compatible with SDL3. I already created a release of node-sdl with this state integrated to test it: https://github.com/bmsuseluda/node-sdl/releases/tag/v0.12.0.